### PR TITLE
Arreglado .exitocampo en index.css de ET2

### DIFF
--- a/ET2/css/index.css
+++ b/ET2/css/index.css
@@ -109,7 +109,7 @@ General
 }
 
 .exitocampo {
-  border: 1px green;
+  border: 1px solid green;
   display: inline-block;
 }
 


### PR DESCRIPTION
Añadido el solid al border de .exitocampo para que se ponga en verde de la misma forma que .errorcampo se pone en rojo. (Ya está en semana8-9 así que supongo que es el comportamiento deseado)