### PR TITLE
Hay que limpiar la lista de ficheros despues de cada test

### DIFF
--- a/ET2/js_app/Tests_class.js
+++ b/ET2/js_app/Tests_class.js
@@ -144,6 +144,8 @@ class test{
 
                 // Set your input `files` to the file list
                 document.getElementById(campotest).files = fileList;
+            } else{
+                document.getElementById(campotest).files = undefined;
             }
 
             //llamo a funcion

--- a/ET2/js_app/Tests_class.js
+++ b/ET2/js_app/Tests_class.js
@@ -145,7 +145,7 @@ class test{
                 // Set your input `files` to the file list
                 document.getElementById(campotest).files = fileList;
             } else{
-                document.getElementById(campotest).files = undefined;
+                document.getElementById(campotest).value = "";
             }
 
             //llamo a funcion


### PR DESCRIPTION
Si en tu prueba de ficheros no le pasas un fichero (un array vacío), el elemento con id del campo de la prueba mantiene el archivo de la anterior prueba en vez de no tener archivo